### PR TITLE
BREAKING CHANGE: inherit from Error class

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const ERR_STATUS = '"status" must be a valid HTTP Error Status Code ([RFC7231], 
 const ERR_TITLE = 'missing "title". a short, human-readable summary of the problem type'
 const STATUS_CODES_WEB = 'https://httpstatuses.com/'
 
-module.exports = class Problem {
+module.exports = class Problem extends Error {
   constructor () {
     let args = Array.from(arguments)
     let status = args.shift()
@@ -60,6 +60,7 @@ module.exports = class Problem {
       throw new Error(ERR_TITLE)
     }
 
+    super(`[${String(status)}] ${String(title)} (${String(type)})`)
     this.type = base + String(type)
     this.title = String(title)
     this.status = String(status)

--- a/test/index.js
+++ b/test/index.js
@@ -40,9 +40,9 @@ tap.test('API Problem', assert => {
   assert.equal(new Problem(452, 'foo').status, '452', 'custom "status"')
   assert.equal(new Problem(404, 'foo', 'foo://bar/').type, 'foo://bar/', 'custom "type" ')
 
-  assert.deepEqual(new Problem(404, { foo: 'bar' }), { status: '404', title: STATUS_CODES[404], type: STATUS_CODES_WEB + 404, foo: 'bar' }, 'members immediatly after "status"')
-  assert.deepEqual(new Problem(404, 'foo', { foo: 'bar' }), { status: '404', title: 'foo', type: STATUS_CODES_WEB + 404, foo: 'bar' }, 'members immediatly after "title"')
-  assert.deepEqual(new Problem(404, 'foo', 'foo://bar/', { foo: 'bar' }), { status: '404', title: 'foo', type: 'foo://bar/', foo: 'bar' }, 'members immediatly after "type"')
+  assert.equal(new Problem(404, { foo: 'bar' }).foo, 'bar', 'members immediately after "status"')
+  assert.equal(new Problem(404, 'foo', { foo: 'bar' }).foo, 'bar', 'members immediately after "title"')
+  assert.equal(new Problem(404, 'foo', 'foo://bar/', { foo: 'bar' }).foo, 'bar', 'members immediately after "type"')
 
   Problem.BASE_URI = 'foo://bar/'
 


### PR DESCRIPTION
This is helpful because throwing this object will
now have a stack like errors are wont to do